### PR TITLE
Add code coverage step to repo

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  test:
+  test_coverage:
     runs-on: ParallelHoss
 
     steps:
@@ -27,7 +27,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -e .[test]
-          coverage run -m pytest --benchmark-disable --ignore scratch
+          coverage run -m pytest --source=genlm_backend --benchmark-disable --ignore scratch
           coverage json --omit "*/test*"
           coverage report --omit "*/test*"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -e .[test]
-          coverage run -m pytest --source=genlm_backend --benchmark-disable --ignore scratch
+          coverage run --source=genlm_backend -m pytest --benchmark-disable
           coverage json --omit "*/test*"
           coverage report --omit "*/test*"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+name: GPU tests + code coverage
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  test:
+    runs-on: ParallelHoss
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.5
+          cache: 'pip'
+
+      - name: Run Tests
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -e .[test]
+          coverage run -m pytest --benchmark-disable --ignore scratch
+          coverage json --omit "*/test*"
+          coverage report --omit "*/test*"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11.5'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        runner: [ubuntu-22.04, ParallelHoss]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -24,18 +21,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11.5
-
-      - name: Cache pip packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.runner }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.runner }}-pip-
+          cache: 'pip'
 
       - name: Run Tests
         run: |
           python -m venv venv
           source venv/bin/activate
           pip install -e .[test]
-          pytest tests/
+          pytest tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Docs](https://github.com/chi-collective/genlm-backend/actions/workflows/docs.yml/badge.svg)](https://probcomp.github.io/genlm-backend/)
 [![Tests](https://github.com/chi-collective/genlm-backend/actions/workflows/pytest.yml/badge.svg)](https://github.com/probcomp/genlm-backend/actions/workflows/pytest.yml)
+[![codecov](https://codecov.io/github/chi-collective/genlm-backend/graph/badge.svg?token=AS70lcuXra)](https://codecov.io/github/chi-collective/genlm-backend)
 
 # GenLM Backend
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "coverage",
     "pytest",
     "pytest-benchmark",
     "arsenal @ git+https://github.com/timvieira/arsenal",


### PR DESCRIPTION
This PR:

- splits a separate `coverage.yml` workflow out from `pytest.yml`; this new action runs on the GPU runner and runs the tests via `coverage`
- `coverage.yml` uploads a code coverage report to codecov.io
- `pytest.yml` now only runs on CPU
- both workflows have a `pip` cache enabled in the way that GitHub Actions wants us to do it
- adds a markdown badge for code coverage to the README