### PR TITLE
Move test dependencies out of pyproject.toml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -e .[test]
+          pip install -r requirements-dev.txt
           coverage run --source=genlm_backend -m pytest --benchmark-disable
           coverage json --omit "*/test*"
           coverage report --omit "*/test*"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,4 +28,5 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -e .[test]
+          pip install -r requirements-dev.txt
           pytest tests

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,5 +18,5 @@ jobs:
 
     - uses: chartboost/ruff-action@v1
       with:
-        version: 0.8.4
+        version: 0.9.9
         args: check --output-format github

--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ git clone git@github.com:probcomp/genlm-backend.git
 cd genlm_backend
 ```
 and install with pip:
+
 ```bash
 pip install .
 ```
+
 This installs the package without development dependencies. For development, install in editable mode with:
+
 ```bash
-pip install -e ".[test,docs]"
+pip install -e ".[docs]"
+pip install -r requirements-dev.txt
 ```
+
 which also installs the dependencies needed for testing (test) and documentation (docs).
 
 ## Requirements
@@ -42,6 +47,7 @@ which also installs the dependencies needed for testing (test) and documentation
 ## Testing
 
 When test dependencies are installed, the test suite can be run via:
+
 ```bash
 pytest tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = [
-    "coverage",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-benchmark",
-    "arsenal @ git+https://github.com/timvieira/arsenal",
-    "datasets",
-    "viztracer",
-    "IPython",
-]
 docs = [
     "mkdocs",
     "mkdocstrings[python]",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+coverage
+pytest
+pytest-asyncio
+pytest-benchmark
+arsenal @ git+https://github.com/timvieira/arsenal
+datasets
+viztracer
+IPython


### PR DESCRIPTION
This change allows us to publish to pypi by cutting the git dependency (arsenal) out of pyproject.toml.